### PR TITLE
Resolve error calling `mtx.A` on coo_matrix object

### DIFF
--- a/mx/mx_normalize.py
+++ b/mx/mx_normalize.py
@@ -54,7 +54,7 @@ def mx_normalize(mtx, method="log1pPF"):
         pre_pf = mtx.sum(axis=1).A.ravel()
         m = sparse.diags(pre_pf.mean() / pre_pf) @ mtx
     elif method == "rank":
-        m = csr_matrix((rankdata(mtx.A, axis=0, method="min"))-1)
+        m = csr_matrix((rankdata(mtx.toarray(), axis=0, method="min"))-1)
     else:
         raise NotImplementedError()
 


### PR DESCRIPTION
For coo_matrix objects calling `mtx.A` gives the following error
```
Traceback (most recent call last):
  File "~/miniconda3/envs/ecmx/bin/mx", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "~/miniconda3/envs/ecmx/lib/python3.12/site-packages/mx/main.py", line 77, in main
    COMMAND_TO_FUNCTION[sys.argv[1]](parser, args)
  File "~/miniconda3/envs/ecmx/lib/python3.12/site-packages/mx/mx_normalize.py", line 35, in validate_mx_normalize_args
    run_mx_normalize(args.matrix, args.output, args.method)
  File "~/miniconda3/envs/ecmx/lib/python3.12/site-packages/mx/mx_normalize.py", line 40, in run_mx_normalize
    n = mx_normalize(mtx, method)
        ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/PHShome/sr1068/miniconda3/envs/ecmx/lib/python3.12/site-packages/mx/mx_normalize.py", line 57, in mx_normalize
    m = csr_matrix((rankdata(mtx.A, axis=0, method="min"))-1)
                             ^^^^^
AttributeError: 'coo_matrix' object has no attribute 'A'
```
This appears to be resolved by switching `mtx.A` to `mtx.toarray()`